### PR TITLE
Fix for WebHDFS API complaint during create file operation: Data upload ...

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -79,7 +79,8 @@ class PyWebHdfsClient(object):
         # initial response from the namenode and make the CREATE request
         #to the datanode
         uri = init_response.headers['location']
-        response = requests.put(uri, data=file_data)
+        response = requests.put(uri, data=file_data,
+            headers={'content-type':'application/octet-stream'})
 
         if not response.status_code == httplib.CREATED:
             _raise_pywebhdfs_exception(response.status_code, response.text)


### PR DESCRIPTION
> > > from pywebhdfs.webhdfs import PyWebHdfsClient
> > > hdfs = PyWebHdfsClient(host='ubuntu@ec2-XXX-X.compute-1.amazonaws.com',port='14000', user_name='httpfs')
> > > my_data = "TESTING TESTING"
> > > my_file = 'user/importer/ashish.txt'
> > > hdfs.create_file(my_file, my_data, overwrite=True)

pywebhdfs.errors.BadRequest: HTTP Status 400 - Data upload requests must have content-type set to 'application/octet-stream

PS: I have setup httpfs on namenode, so instead of using port 50070, I am using port 14000 in creating PyWebHdfsClient
