### PR TITLE
Changed append_file() to use content type application/octet-stream

### DIFF
--- a/pywebhdfs/webhdfs.py
+++ b/pywebhdfs/webhdfs.py
@@ -135,7 +135,9 @@ class PyWebHdfsClient(object):
         # initial response from the namenode and make the APPEND request
         #to the datanode
         uri = init_response.headers['location']
-        response = requests.post(uri, data=file_data)
+        response = requests.post(
+            uri, data=file_data,
+            headers={'content-type': 'application/octet-stream'})
 
         if not response.status_code == httplib.OK:
             _raise_pywebhdfs_exception(response.status_code, response.text)


### PR DESCRIPTION
I was getting the following 400 error when sending append requests to my Cloudera Hadoop HDFS installation.

HTTP Status 400 - Data upload requests must have content-type set to 'application/octet-stream'

I saw that create_file() specifies a content type of 'application/octet-stream', but not append_file(). append_file() worked once I started specifying 'application/octet-stream'.

System stats:

Cloudera Hadoop version 2.0.0-cdh4.4.0, installed on CentOS 6.4 using the Cloudera YUM repos.
